### PR TITLE
Fix const char  errors

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -12,7 +12,7 @@
 
 - Added changelog
 
-## [1.1.0] - 13 Aug 2025
+## [1.1.0] - 16 Aug 2025
 
 - Added two new overloads to setYellowTitle and printToBufferBlue for const char* arguments
 


### PR DESCRIPTION
Added two new overloads to **setYellowTitle** and **printToBufferBlue** for const char* arguments which fixes the complaints about const char* for arguments specified as char*.